### PR TITLE
chore: add section to note when all requirements are satisfied

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,13 @@
 
 <!-- ✍️ If necessary, please describe the impact and migration path -->
 
+**Are all of the original requirements satisfied in this PR?** <!-- ✍️ Yes/No -->
+
+<!-- ✍️
+Sometimes it can be useful to break up a changeset to multiple PR, and sometimes changes in multiple repos are required 
+If necessary, please note the requirements which will be handled separately and link to any other PRs when possible.
+-->
+
 ## What is the current behavior? <!-- Remove if this a brand new feature -->
 
 <!-- ✍️  Describe the changes and provide relevant screenshots for interface changes -->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -32,7 +32,7 @@ If necessary, please note the requirements which will be handled separately and 
 <!-- ✍️
 - [x] Please check using "x"  -->
 - [ ] The title of this PR follows the [conventional commit guidelines](https://openmail.atlassian.net/wiki/spaces/MAP/pages/2801696776/Conventional+Commits)
-- [ ] Acceptance criteria from the original issue has been satisfied
+- [ ] Acceptance criteria from the original issue has been satisfied or will be covered by multiple PRs
 - [ ] I have performed a self-review of my code and the expected functionality
 - [ ] I have added tests that prove that my feature works or my fix is effective
 - [ ] I have made any necessary changes to the documentation


### PR DESCRIPTION
Adds a section to the Pull Request template to call out when all original requirements are satisfied.

In some cases it can be useful to break up one Jira task into multiple pull requests to the same repo, and in other cases the requirements mean that changes are made to multiple repositories. In both cases it can sometimes be hard for a reviewer to understand whether a missing requirement is intentional or was simply missed.

The goal of this section is to facilitate better communication that the author, to the best of their knowledge, have either satisfied all the original requirements or they are aware and have a plan to address the remaining requirements before the issue is closed.